### PR TITLE
chore: upgrade sdk and gradle version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,7 @@ android/build/
 .gradle
 local.properties
 *.iml
+
+# Gradle files
+.gradle/
+build/

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,20 +5,24 @@ description = 'react-native-biometrics'
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0"
     }
@@ -29,8 +33,12 @@ android {
 
 repositories {
     mavenCentral()
+    maven {
+        url 'https://maven.google.com/'
+        name 'Google'
+    }
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
sdk version under 26 was deprecated in august 2018.

solves #12

refs #11