### PR TITLE
feat: enhance ios error

### DIFF
--- a/ios/ReactNativeBiometrics.m
+++ b/ios/ReactNativeBiometrics.m
@@ -35,7 +35,8 @@ RCT_EXPORT_METHOD(createKeys: (NSString *)promptMessage resolver:(RCTPromiseReso
         if (success) {
           [self createAndStoreKeyPair:resolve rejecter:reject];
         } else {
-          reject(@"fingerprint_error", @"Could not confirm fingerprint", nil);
+          NSString *message = [NSString stringWithFormat:@"Fingerprint error: %@", fingerprintError];
+          reject(@"fingerprint_error", message, nil);
         }
       }];
     }
@@ -145,7 +146,8 @@ RCT_EXPORT_METHOD(simplePrompt: (NSString *)promptMessage resolver:(RCTPromiseRe
       if (success) {
         resolve(@(YES));
       } else {
-        reject(@"fingerprint_error", @"Could not confirm fingerprint", nil);
+        NSString *message = [NSString stringWithFormat:@"Fingerprint error: %@", fingerprintError];
+        reject(@"fingerprint_error", message, nil);
       }
     }];
   });


### PR DESCRIPTION
On `iOS`, when `simplePrompt()` is called, it can show two pop-ups, the
first one from the system asking the user to allow `biometry` for the app
and then the one to input `biometry`. The user can cancel on both
scenarios and errors being thrown should be different so that the app
can treat them separately.