### PR TITLE
Typescript - Add type alias for biometryType

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -2,9 +2,14 @@ import { NativeModules } from 'react-native';
 
 const { ReactNativeBiometrics: bridge } = NativeModules;
 
+/** 
+ * Type alias for possible biometry types
+ */
+export type BiometryType = 'TouchID' | 'FaceID' | 'Biometrics';
+
 interface IsSensorAvailableResult {
     available: boolean
-    biometryType?: string
+    biometryType?: BiometryType
     error?: string
 }
 


### PR DESCRIPTION
Hi,

This PR aims to slightly improve type safety and convenience when using typescript along with `biometryType` values.

From what I understand, `biometryType` can only be one of `TouchID`, `FaceID` or `Biometrics`. However, when you call `isSensorAvailable()` it returns `biometryType` as a plain string. It could be a bit stricter to help IDEs autocompletion and enforce correct typings on the library users' side.

In my case, without this, I would define a type `BiometryType` on my side and then cast the received string value blindly or write a mapping function that compares to your exported constants.

Thanks for this awesome library, it really has everything we needed! 👍 