### PR TITLE
Android - Check for other type of user cancellation

### DIFF
--- a/android/src/main/java/com/rnbiometrics/CreateSignatureCallback.java
+++ b/android/src/main/java/com/rnbiometrics/CreateSignatureCallback.java
@@ -25,7 +25,7 @@ public class CreateSignatureCallback extends BiometricPrompt.AuthenticationCallb
     public void onAuthenticationError(int errorCode, @NonNull CharSequence errString) {
         super.onAuthenticationError(errorCode, errString);
         super.onAuthenticationError(errorCode, errString);
-        if (errorCode == BiometricPrompt.ERROR_NEGATIVE_BUTTON) {
+        if (errorCode == BiometricPrompt.ERROR_NEGATIVE_BUTTON || errorCode == BiometricPrompt.ERROR_USER_CANCELED ) {
             WritableMap resultMap = new WritableNativeMap();
             resultMap.putBoolean("success", false);
             resultMap.putString("error", "User cancellation");

--- a/android/src/main/java/com/rnbiometrics/SimplePromptCallback.java
+++ b/android/src/main/java/com/rnbiometrics/SimplePromptCallback.java
@@ -18,7 +18,7 @@ public class SimplePromptCallback extends BiometricPrompt.AuthenticationCallback
     @Override
     public void onAuthenticationError(int errorCode, @NonNull CharSequence errString) {
         super.onAuthenticationError(errorCode, errString);
-        if (errorCode == BiometricPrompt.ERROR_NEGATIVE_BUTTON) {
+        if (errorCode == BiometricPrompt.ERROR_NEGATIVE_BUTTON || errorCode == BiometricPrompt.ERROR_USER_CANCELED) {
             WritableMap resultMap = new WritableNativeMap();
             resultMap.putBoolean("success", false);
             resultMap.putString("error", "User cancellation");


### PR DESCRIPTION
On Android, users can cancel the biometric prompt by tapping outside the prompt. 
However, this results in a different error code than the cancel button and that error code is not checked for. 
This PR simply adds a check for the other error code so that both types of user cancellations can be handled in one place in javascript, as the documentation leads us to believe.