### PR TITLE
Remove unused string from call to createKeys in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ __Example__
 ```js
 import ReactNativeBiometrics from 'react-native-biometrics'
 
-ReactNativeBiometrics.createKeys('Confirm fingerprint')
+ReactNativeBiometrics.createKeys()
   .then((resultObject) => {
     const { publicKey } = resultObject
     console.log(publicKey)


### PR DESCRIPTION
Looking at source for the `createKeys` method, it seems like it doesn't do anything with any arguments.