### PR TITLE
Add device credentials support to simplePrompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ __Options Object__
 | promptMessage | string | Message that will be displayed in the fingerprint or face id prompt | ✔ | ✔ |
 | payload | string | String of data to be signed by the RSA signature | ✔ | ✔ |
 | cancelButtonText | string | Text to be displayed for the cancel button on biometric prompts, defaults to `Cancel` | ✖ | ✔ |
+| allowDeviceCredentials | boolean | If true, the user can use the device credential (pattern or pin code) | ✖ | ✔ |
 
 __Result Object__
 

--- a/android/src/main/java/com/rnbiometrics/ReactNativeBiometrics.java
+++ b/android/src/main/java/com/rnbiometrics/ReactNativeBiometrics.java
@@ -190,6 +190,7 @@ public class ReactNativeBiometrics extends ReactContextBaseJavaModule {
                         public void run() {
                             try {
                                 String cancelButtomText = params.getString("cancelButtonText");
+                                Boolean allowDeviceCredentials = params.getBoolean("allowDeviceCredentials");
                                 String promptMessage = params.getString("promptMessage");
 
                                 AuthenticationCallback authCallback = new SimplePromptCallback(promise);
@@ -197,12 +198,21 @@ public class ReactNativeBiometrics extends ReactContextBaseJavaModule {
                                 Executor executor = Executors.newSingleThreadExecutor();
                                 BiometricPrompt biometricPrompt = new BiometricPrompt(fragmentActivity, executor, authCallback);
 
-                                PromptInfo promptInfo = new PromptInfo.Builder()
+                                if (allowDeviceCredentials) {
+                                    PromptInfo promptInfo = new PromptInfo.Builder()
+                                        .setTitle(promptMessage)
+                                        .setDeviceCredentialAllowed(true)
+                                        .build();
+                                    biometricPrompt.authenticate(promptInfo);
+                                } else {
+                                    PromptInfo promptInfo = new PromptInfo.Builder()
+                                        .setTitle(promptMessage)
                                         .setDeviceCredentialAllowed(false)
                                         .setNegativeButtonText(cancelButtomText)
-                                        .setTitle(promptMessage)
                                         .build();
-                                biometricPrompt.authenticate(promptInfo);
+                                    biometricPrompt.authenticate(promptInfo);
+                                }
+                                
                             } catch (Exception e) {
                                 promise.reject("Error displaying local biometric prompt: " + e.getMessage(), "Error displaying local biometric prompt: " + e.getMessage());
                             }

--- a/index.ts
+++ b/index.ts
@@ -39,7 +39,8 @@ interface CreateSignatureResult {
 
 interface SimplePromptOptions {
     promptMessage: string
-    cancelButtonText?: string
+    cancelButtonText?: string,
+    allowDeviceCredentials?: boolean
 }
 
 interface SimplePromptResult {
@@ -120,11 +121,16 @@ module ReactNativeBiometrics {
      * @param {Object} simplePromptOptions
      * @param {string} simplePromptOptions.promptMessage
      * @param {string} simplePromptOptions.cancelButtonText (Android only)
+     * @param {string} simplePromptOptions.allowDeviceCredentials (Android only)
      * @returns {Promise<Object>}  Promise that resolves an object with details about the biometrics result
      */
     export function simplePrompt(simplePromptOptions: SimplePromptOptions): Promise<SimplePromptResult> {
         if (!simplePromptOptions.cancelButtonText) {
             simplePromptOptions.cancelButtonText = 'Cancel';
+        }
+
+        if (!simplePromptOptions.allowDeviceCredentials) {
+            simplePromptOptions.allowDeviceCredentials = false;
         }
 
         return bridge.simplePrompt(simplePromptOptions);


### PR DESCRIPTION
### Add device credentials support to simplePrompt

## Tasks
- [x] Add an extra param to support device credential on `simplePrompt`
- [x] Update Android file to support device credential
