### PR TITLE
feat: expose Android's BIOMETRIC_ERROR message

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ __Example__
 
 ```js
 import ReactNativeBiometrics from 'react-native-biometrics'
+import {Alert} from 'react-native';
 
 ReactNativeBiometrics.isSensorAvailable()
   .then((resultObject) => {
@@ -125,6 +126,23 @@ ReactNativeBiometrics.isSensorAvailable()
       console.log('Biometrics is supported')
     } else {
       console.log('Biometrics not supported')
+
+      // for iOS, since every iOS device has either TouchID or FaceID after iPhone5s
+      let message = 'Please go to settings to our app accessing your touch / face id';
+
+      // for android, check for different conditions
+      if (Platform.OS === 'android') {
+        if (error === ReactNativeBiometrics.BiometricErrorAndroid.NONE_ENROLLED) {
+          message = 'Please go to settings, and create your biometric credential';
+        } else if (error === ReactNativeBiometrics.BiometricErrorAndroid.NO_HARDWARE) {
+          message = 'No biometric features available on this device';
+        } else if (error === ReactNativeBiometrics.BiometricErrorAndroid.HW_UNAVAILBLE) {
+          message = 'Biometric features are currently unavailable';
+        }
+      }
+        
+      // hint the users about their next move
+      Alert.alert('Warning', message, [{text: 'Got it'}]);
     }
   })
 ```

--- a/index.ts
+++ b/index.ts
@@ -60,6 +60,14 @@ module ReactNativeBiometrics {
      * Enum for generic biometrics (this is the only value available on android)
      */
     export const Biometrics = 'Biometrics';
+    /**
+     * Enum for android's predefined error cases  
+     */
+    export const BiometricErrorAndroid = {
+        NO_HARDWARE: "BIOMETRIC_ERROR_NO_HARDWARE",
+        HW_UNAVAILBLE: "BIOMETRIC_ERROR_HW_UNAVAILABLE",
+        NONE_ENROLLED: "BIOMETRIC_ERROR_NONE_ENROLLED"
+    };
 
     /**
      * Returns promise that resolves to an object with object.biometryType = Biometrics | TouchID | FaceID


### PR DESCRIPTION
Hi, thanks for the lib, it works pretty well.

In this simple PR, I'd like to export Android's BIOMETRIC_ERROR_XXX messages. The reason for this is, we can provide better user hint after calling `isSensorAvailable`, the idea looks like this:
```javascript
import ReactNativeBiometrics from 'react-native-biometrics'
import {Alert} from 'react-native';

ReactNativeBiometrics.isSensorAvailable()
  .then((resultObject) => {
    const { available, biometryType } = resultObject

    if (available && biometryType === ReactNativeBiometrics.TouchID) {
      console.log('TouchID is supported')
    } else if (available && biometryType === ReactNativeBiometrics.FaceID) {
      console.log('FaceID is supported')
    } else if (available && biometryType === ReactNativeBiometrics.Biometrics) {
      console.log('Biometrics is supported')
    } else {
      console.log('Biometrics not supported')

      // for iOS, since every iOS device has either TouchID or FaceID after iPhone5s
      let message = 'Please go to settings to our app accessing your touch / face id';

      // for android, check for different conditions
      if (Platform.OS === 'android') {
        if (error === ReactNativeBiometrics.BiometricErrorAndroid.NONE_ENROLLED) {
          message = 'Please go to settings, and create your biometric credential';
        } else if (error === ReactNativeBiometrics.BiometricErrorAndroid.NO_HARDWARE) {
          message = 'No biometric features available on this device';
        } else if (error === ReactNativeBiometrics.BiometricErrorAndroid.HW_UNAVAILBLE) {
          message = 'Biometric features are currently unavailable';
        }
      }
        
      // hint the users about their next move
      Alert.alert('Warning', message, [{text: 'Got it'}]);
    }
  })
```

README.md is updated as well.

Thanks!
