### PR TITLE
Unify allowDeviceCredentials API

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This package is designed to make server authentication using biometrics easier. 
 
 When a user enrolls in biometrics, a key pair is generated.  The private key is stored securely on the device and the public key is sent to a server for registration.  When the user wishes to authenticate, the user is prompted for biometrics, which unlocks the securely stored private key.  Then a cryptographic signature is generated and sent to the server for verification.  The server then verifies the signature.  If the verification was successful, the server returns an appropriate response and authorizes the user.
 
-## Constants
+## Biometry Types
 
 ### TouchID (iOS only)
 
@@ -105,7 +105,16 @@ if (biometryType === BiometryTypes.Biometrics) {
 __Options Object__
 | Parameter | Type | Description | iOS | Android |
 | --- | --- | --- | --- | --- |
-| allowDeviceCredentials | boolean | Boolean that will enable the user to opt to use their device passcode to bypass biometric authentication. Note: This feature is not supported in Android versions prior to API 30. | ✔ | ✔ |
+| allowDeviceCredentials | boolean | Boolean that will enable the ability for the device passcode to be used instead of biometric information. On iOS, the prompt will only be shown after biometrics has failed twice. On Android, the prompt will be shown on the biometric prompt and does not require the user to attempt to use biometrics information first. Note: This feature is not supported on Android versions prior to API 30. | ✔ | ✔ |
+
+__Example__
+
+```js
+import ReactNativeBiometrics from 'react-native-biometrics'
+
+const biometrics = new ReactNativeBiometrics({ allowDeviceCredentials: true }
+
+```
 
 ### isSensorAvailable()
 

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ A constant for the touch id sensor type, evaluates to `'TouchID'`
 __Example__
 
 ```js
-import ReactNativeBiometrics from 'react-native-biometrics'
+import ReactNativeBiometrics, { BiometryTypes } from 'react-native-biometrics'
 
-const { biometryType } = await ReactNativeBiometrics.isSensorAvailable()
+const { biometryType } = await new ReactNativeBiometrics().isSensorAvailable()
 
-if (biometryType === ReactNativeBiometrics.TouchID) {
+if (biometryType === BiometryTypes.TouchID) {
   //do something fingerprint specific
 }
 ```
@@ -73,11 +73,11 @@ A constant for the face id sensor type, evaluates to `'FaceID'`
 __Example__
 
 ```js
-import ReactNativeBiometrics from 'react-native-biometrics'
+import ReactNativeBiometrics, { BiometryTypes } from 'react-native-biometrics'
 
-const { biometryType } = await ReactNativeBiometrics.isSensorAvailable()
+const { biometryType } = await new ReactNativeBiometrics().isSensorAvailable()
 
-if (biometryType === ReactNativeBiometrics.FaceID) {
+if (biometryType === BiometryTypes.FaceID) {
   //do something face id specific
 }
 ```
@@ -89,25 +89,27 @@ A constant for generic Biometrics, evaluates to `'Biometrics'`
 __Example__
 
 ```js
-import ReactNativeBiometrics from 'react-native-biometrics'
+import ReactNativeBiometrics, { BiometryTypes } from 'react-native-biometrics'
 
-const { biometryType } = await ReactNativeBiometrics.isSensorAvailable()
+const { biometryType } = await new ReactNativeBiometrics().isSensorAvailable()
 
-if (biometryType === ReactNativeBiometrics.Biometrics) {
+if (biometryType === BiometryTypes.Biometrics) {
   //do something face id specific
 }
 ```
 
-## Methods
+## Class
 
-### isSensorAvailable()
-
-Detects what type of biometric sensor is available.  Returns a `Promise` that resolves to an object with details about biometrics availability
+## Constructor
 
 __Options Object__
 | Parameter | Type | Description | iOS | Android |
 | --- | --- | --- | --- | --- |
 | allowDeviceCredentials | boolean | Boolean that will enable the user to opt to use their device passcode to bypass biometric authentication. Note: This feature is not supported in Android versions prior to API 30. | ✔ | ✔ |
+
+### isSensorAvailable()
+
+Detects what type of biometric sensor is available.  Returns a `Promise` that resolves to an object with details about biometrics availability
 
 __Result Object__
 
@@ -120,17 +122,17 @@ __Result Object__
 __Example__
 
 ```js
-import ReactNativeBiometrics from 'react-native-biometrics'
+import ReactNativeBiometrics, { BiometryTypes } from 'react-native-biometrics'
 
-ReactNativeBiometrics.isSensorAvailable()
+new ReactNativeBiometrics().isSensorAvailable()
   .then((resultObject) => {
     const { available, biometryType } = resultObject
 
-    if (available && biometryType === ReactNativeBiometrics.TouchID) {
+    if (available && biometryType === BiometryTypes.TouchID) {
       console.log('TouchID is supported')
-    } else if (available && biometryType === ReactNativeBiometrics.FaceID) {
+    } else if (available && biometryType === BiometryTypes.FaceID) {
       console.log('FaceID is supported')
-    } else if (available && biometryType === ReactNativeBiometrics.Biometrics) {
+    } else if (available && biometryType === BiometryTypes.Biometrics) {
       console.log('Biometrics is supported')
     } else {
       console.log('Biometrics not supported')
@@ -141,11 +143,6 @@ ReactNativeBiometrics.isSensorAvailable()
 ### createKeys()
 
 Generates a public private RSA 2048 key pair that will be stored in the device keystore.  Returns a `Promise` that resolves to an object providing details about the keys.
-
-__Options Object__
-| Parameter | Type | Description | iOS | Android |
-| --- | --- | --- | --- | --- |
-| allowDeviceCredentials | boolean | Boolean that will enable the user to opt to use their device passcode to bypass biometric authentication. Note: This option is only needed to make iOS support for passcode fallback work. | ✔ | ✖ |
 
 __Result Object__
 
@@ -158,7 +155,7 @@ __Example__
 ```js
 import ReactNativeBiometrics from 'react-native-biometrics'
 
-ReactNativeBiometrics.createKeys()
+new ReactNativeBiometrics().createKeys()
   .then((resultObject) => {
     const { publicKey } = resultObject
     console.log(publicKey)
@@ -181,7 +178,7 @@ __Example__
 ```js
 import ReactNativeBiometrics from 'react-native-biometrics'
 
-ReactNativeBiometrics.biometricKeysExist()
+new ReactNativeBiometrics().biometricKeysExist()
   .then((resultObject) => {
     const { keysExist } = resultObject
 
@@ -208,7 +205,7 @@ __Example__
 ```js
 import ReactNativeBiometrics from 'react-native-biometrics'
 
-ReactNativeBiometrics.deleteKeys()
+new ReactNativeBiometrics().deleteKeys()
   .then((resultObject) => {
     const { keysDeleted } = resultObject
 
@@ -233,7 +230,6 @@ __Options Object__
 | promptMessage | string | Message that will be displayed in the fingerprint or face id prompt | ✔ | ✔ |
 | payload | string | String of data to be signed by the RSA signature | ✔ | ✔ |
 | cancelButtonText | string | Text to be displayed for the cancel button on biometric prompts, defaults to `Cancel` | ✖ | ✔ |
-| allowDeviceCredentials | boolean | Boolean that will enable the user to opt to use their device passcode to bypass biometric authentication. Note: This feature is not supported in Android versions prior to API 30. | ✔ | ✔ |
 
 __Result Object__
 
@@ -251,7 +247,7 @@ import ReactNativeBiometrics from 'react-native-biometrics'
 let epochTimeSeconds = Math.round((new Date()).getTime() / 1000).toString()
 let payload = epochTimeSeconds + 'some message'
 
-ReactNativeBiometrics.createSignature({
+new ReactNativeBiometrics().createSignature({
     promptMessage: 'Sign in',
     payload: payload
   })
@@ -278,7 +274,6 @@ __Options Object__
 | promptMessage | string | Message that will be displayed in the biometrics prompt | ✔ | ✔ |
 | fallbackPromptMessage | string | Message that will be shown when FaceID or TouchID has failed and a passcode has been set on the device. | ✔ | ✖ |
 | cancelButtonText | string | Text to be displayed for the cancel button on biometric prompts, defaults to `Cancel` | ✖ | ✔ |
-| allowDeviceCredentials | boolean | Boolean that will enable the user to opt to use their device passcode to bypass biometric authentication. Note: This feature is not supported in Android versions prior to API 30. | ✔ | ✔ |
 
 __Result Object__
 
@@ -292,7 +287,7 @@ __Example__
 ```js
 import ReactNativeBiometrics from 'react-native-biometrics'
 
-ReactNativeBiometrics.simplePrompt({promptMessage: 'Confirm fingerprint'})
+new ReactNativeBiometrics().simplePrompt({promptMessage: 'Confirm fingerprint'})
   .then((resultObject) => {
     const { success } = resultObject
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ __Example__
 ```js
 import ReactNativeBiometrics, { BiometryTypes } from 'react-native-biometrics'
 
-const { biometryType } = await new ReactNativeBiometrics().isSensorAvailable()
+const rnBiometrics = new ReactNativeBiometrics()
+
+const { biometryType } = await rnBiometrics.isSensorAvailable()
 
 if (biometryType === BiometryTypes.TouchID) {
   //do something fingerprint specific
@@ -75,7 +77,9 @@ __Example__
 ```js
 import ReactNativeBiometrics, { BiometryTypes } from 'react-native-biometrics'
 
-const { biometryType } = await new ReactNativeBiometrics().isSensorAvailable()
+const rnBiometrics = new ReactNativeBiometrics()
+
+const { biometryType } = await rnBiometrics.isSensorAvailable()
 
 if (biometryType === BiometryTypes.FaceID) {
   //do something face id specific
@@ -91,7 +95,9 @@ __Example__
 ```js
 import ReactNativeBiometrics, { BiometryTypes } from 'react-native-biometrics'
 
-const { biometryType } = await new ReactNativeBiometrics().isSensorAvailable()
+const rnBiometrics = new ReactNativeBiometrics()
+
+const { biometryType } = await rnBiometrics.isSensorAvailable()
 
 if (biometryType === BiometryTypes.Biometrics) {
   //do something face id specific
@@ -112,7 +118,10 @@ __Example__
 ```js
 import ReactNativeBiometrics from 'react-native-biometrics'
 
-const biometrics = new ReactNativeBiometrics({ allowDeviceCredentials: true }
+const rnBiometrics = new ReactNativeBiometrics({ allowDeviceCredentials: true })
+
+// Perform operations as normal
+// All prompts will allow for fallback to the device's credentials for authentication
 
 ```
 
@@ -133,7 +142,9 @@ __Example__
 ```js
 import ReactNativeBiometrics, { BiometryTypes } from 'react-native-biometrics'
 
-new ReactNativeBiometrics().isSensorAvailable()
+const rnBiometrics = new ReactNativeBiometrics()
+
+rnBiometrics.isSensorAvailable()
   .then((resultObject) => {
     const { available, biometryType } = resultObject
 
@@ -164,7 +175,9 @@ __Example__
 ```js
 import ReactNativeBiometrics from 'react-native-biometrics'
 
-new ReactNativeBiometrics().createKeys()
+const rnBiometrics = new ReactNativeBiometrics()
+
+rnBiometrics.createKeys()
   .then((resultObject) => {
     const { publicKey } = resultObject
     console.log(publicKey)
@@ -187,7 +200,8 @@ __Example__
 ```js
 import ReactNativeBiometrics from 'react-native-biometrics'
 
-new ReactNativeBiometrics().biometricKeysExist()
+const rnBiometrics = new ReactNativeBiometrics()
+rnBiometrics.biometricKeysExist()
   .then((resultObject) => {
     const { keysExist } = resultObject
 
@@ -214,7 +228,9 @@ __Example__
 ```js
 import ReactNativeBiometrics from 'react-native-biometrics'
 
-new ReactNativeBiometrics().deleteKeys()
+const rnBiometrics = new ReactNativeBiometrics()
+
+rnBiometrics.deleteKeys()
   .then((resultObject) => {
     const { keysDeleted } = resultObject
 
@@ -256,7 +272,9 @@ import ReactNativeBiometrics from 'react-native-biometrics'
 let epochTimeSeconds = Math.round((new Date()).getTime() / 1000).toString()
 let payload = epochTimeSeconds + 'some message'
 
-new ReactNativeBiometrics().createSignature({
+const rnBiometrics = new ReactNativeBiometrics()
+
+rnBiometrics.createSignature({
     promptMessage: 'Sign in',
     payload: payload
   })
@@ -296,7 +314,9 @@ __Example__
 ```js
 import ReactNativeBiometrics from 'react-native-biometrics'
 
-new ReactNativeBiometrics().simplePrompt({promptMessage: 'Confirm fingerprint'})
+const rnBiometrics = new ReactNativeBiometrics()
+
+rnBiometrics.simplePrompt({promptMessage: 'Confirm fingerprint'})
   .then((resultObject) => {
     const { success } = resultObject
 

--- a/index.ts
+++ b/index.ts
@@ -1,157 +1,166 @@
-import { NativeModules } from 'react-native';
+import { NativeModules } from 'react-native'
 
-const { ReactNativeBiometrics: bridge } = NativeModules;
+const { ReactNativeBiometrics: bridge } = NativeModules
 
-/** 
+/**
  * Type alias for possible biometry types
  */
-export type BiometryType = 'TouchID' | 'FaceID' | 'Biometrics';
+export type BiometryType = 'TouchID' | 'FaceID' | 'Biometrics'
 
-interface IsSensorAvailableOptions {
-    allowDeviceCredentials?: boolean
+interface RNBiometricsOptions {
+  allowDeviceCredentials?: boolean
 }
 
 interface IsSensorAvailableResult {
-    available: boolean
-    biometryType?: BiometryType
-    error?: string
-}
-
-interface CreateKeysOptions {
-    allowDeviceCredentials?: boolean
+  available: boolean
+  biometryType?: BiometryType
+  error?: string
 }
 
 interface CreateKeysResult {
-    publicKey: string
+  publicKey: string
 }
 
 interface BiometricKeysExistResult {
-    keysExist: boolean
+  keysExist: boolean
 }
 
 interface DeleteKeysResult {
-    keysDeleted: boolean
+  keysDeleted: boolean
 }
 
 interface CreateSignatureOptions {
-    promptMessage: string
-    payload: string
-    cancelButtonText?: string
-    allowDeviceCredentials?: boolean
+  promptMessage: string
+  payload: string
+  cancelButtonText?: string
 }
 
 interface CreateSignatureResult {
-    success: boolean
-    signature?: string
-    error?: string
+  success: boolean
+  signature?: string
+  error?: string
 }
 
 interface SimplePromptOptions {
-    promptMessage: string
-    fallbackPromptMessage?: string
-    cancelButtonText?: string
-    allowDeviceCredentials?: boolean
+  promptMessage: string
+  fallbackPromptMessage?: string
+  cancelButtonText?: string
 }
 
 interface SimplePromptResult {
-    success: boolean
-    error?: string
+  success: boolean
+  error?: string
 }
 
-module ReactNativeBiometrics {
-    /**
-     * Enum for touch id sensor type
-     */
-    export const TouchID = 'TouchID';
-    /**
-     * Enum for face id sensor type
-     */
-    export const FaceID = 'FaceID';
-    /**
-     * Enum for generic biometrics (this is the only value available on android)
-     */
-    export const Biometrics = 'Biometrics';
+/**
+ * Enum for touch id sensor type
+ */
+export const TouchID = 'TouchID'
+/**
+ * Enum for face id sensor type
+ */
+export const FaceID = 'FaceID'
+/**
+ * Enum for generic biometrics (this is the only value available on android)
+ */
+export const Biometrics = 'Biometrics'
 
-    /**
-     * Returns promise that resolves to an object with object.biometryType = Biometrics | TouchID | FaceID
-     * @param {Object} isSensorAvailableOptions
-     * @param {boolean} isSensorAvailableOptions.allowDeviceCredentials
-     * @returns {Promise<Object>} Promise that resolves to an object with details about biometrics available
-     */
-    export function isSensorAvailable(isSensorAvailableOptions?: IsSensorAvailableOptions): Promise<IsSensorAvailableResult> {
-        const options = {
-          allowDeviceCredentials: isSensorAvailableOptions?.allowDeviceCredentials ?? false
-        }
-
-        return bridge.isSensorAvailable(options);
-    }
-    /**
-     * Creates a public private key pair,returns promise that resolves to
-     * an object with object.publicKey, which is the public key of the newly generated key pair
-     * @param {Object} createKeysOptions
-     * @param {boolean} createKeysOptions.allowDeviceCredentials
-     * @returns {Promise<Object>}  Promise that resolves to object with details about the newly generated public key
-     */
-    export function createKeys(createKeysOptions?: CreateKeysOptions): Promise<CreateKeysResult> {
-        const options = {
-          allowDeviceCredentials: createKeysOptions?.allowDeviceCredentials ?? false
-        }
-
-        return bridge.createKeys(options);
-    }
-
-    /**
-     * Returns promise that resolves to an object with object.keysExists = true | false
-     * indicating if the keys were found to exist or not
-     * @returns {Promise<Object>} Promise that resolves to object with details aobut the existence of keys
-     */
-    export function biometricKeysExist(): Promise<BiometricKeysExistResult> {
-        return bridge.biometricKeysExist();
-    }
-
-    /**
-     * Returns promise that resolves to an object with true | false
-     * indicating if the keys were properly deleted
-     * @returns {Promise<Object>} Promise that resolves to an object with details about the deletion
-     */
-    export function deleteKeys(): Promise<DeleteKeysResult> {
-        return bridge.deleteKeys();
-    }
-
-    /**
-     * Prompts user with biometrics dialog using the passed in prompt message and
-     * returns promise that resolves to an object with object.signature,
-     * which is cryptographic signature of the payload
-     * @param {Object} createSignatureOptions
-     * @param {string} createSignatureOptions.promptMessage
-     * @param {string} createSignatureOptions.payload
-     * @param {boolean} createSignatureOptions.allowDeviceCredentials
-     * @returns {Promise<Object>}  Promise that resolves to an object cryptographic signature details
-     */
-    export function createSignature(createSignatureOptions: CreateSignatureOptions): Promise<CreateSignatureResult> {
-        createSignatureOptions.cancelButtonText = createSignatureOptions.cancelButtonText ?? 'Cancel';
-        createSignatureOptions.allowDeviceCredentials = createSignatureOptions.allowDeviceCredentials ?? false
-
-        return bridge.createSignature(createSignatureOptions);
-    }
-
-    /**
-     * Prompts user with biometrics dialog using the passed in prompt message and
-     * returns promise that resolves to an object with object.success = true if the user passes,
-     * object.success = false if the user cancels, and rejects if anything fails
-     * @param {Object} simplePromptOptions
-     * @param {string} simplePromptOptions.promptMessage
-     * @param {string} simplePromptOptions.fallbackPromptMessage
-     * @param {boolean} simplePromptOptions.allowDeviceCredentials
-     * @returns {Promise<Object>}  Promise that resolves an object with details about the biometrics result
-     */
-    export function simplePrompt(simplePromptOptions: SimplePromptOptions): Promise<SimplePromptResult> {
-        simplePromptOptions.cancelButtonText = simplePromptOptions.cancelButtonText ?? 'Cancel';
-        simplePromptOptions.fallbackPromptMessage = simplePromptOptions.fallbackPromptMessage ?? 'Use Passcode';
-        simplePromptOptions.allowDeviceCredentials = simplePromptOptions.allowDeviceCredentials ?? false
-
-        return bridge.simplePrompt(simplePromptOptions);
-    }
+export const BiometryTypes = {
+  TouchID,
+  FaceID,
+  Biometrics
 }
 
-export default ReactNativeBiometrics;
+class ReactNativeBiometrics {
+  allowDeviceCredentials = false
+
+  /**
+   * Prompts user with biometrics dialog using the passed in prompt message and
+   * returns promise that resolves to an object with object.signature,
+   * which is cryptographic signature of the payload
+   * @param {Object} rnBiometricsOptions
+   * @param {boolean} rnBiometricsOptions.allowDeviceCredentials
+   */
+  constructor(rnBiometricsOptions?: RNBiometricsOptions) {
+    const allowDeviceCredentials = rnBiometricsOptions?.allowDeviceCredentials ?? false
+    this.allowDeviceCredentials = allowDeviceCredentials
+  }
+
+  /**
+   * Returns promise that resolves to an object with object.biometryType = Biometrics | TouchID | FaceID
+   * @returns {Promise<Object>} Promise that resolves to an object with details about biometrics available
+   */
+  isSensorAvailable(): Promise<IsSensorAvailableResult> {
+    return bridge.isSensorAvailable({
+      allowDeviceCredentials: this.allowDeviceCredentials
+    })
+  }
+
+  /**
+   * Creates a public private key pair,returns promise that resolves to
+   * an object with object.publicKey, which is the public key of the newly generated key pair
+   * @returns {Promise<Object>}  Promise that resolves to object with details about the newly generated public key
+   */
+  createKeys(): Promise<CreateKeysResult> {
+    return bridge.createKeys({
+      allowDeviceCredentials: this.allowDeviceCredentials
+    })
+  }
+
+  /**
+   * Returns promise that resolves to an object with object.keysExists = true | false
+   * indicating if the keys were found to exist or not
+   * @returns {Promise<Object>} Promise that resolves to object with details aobut the existence of keys
+   */
+  biometricKeysExist(): Promise<BiometricKeysExistResult> {
+    return bridge.biometricKeysExist()
+  }
+
+  /**
+   * Returns promise that resolves to an object with true | false
+   * indicating if the keys were properly deleted
+   * @returns {Promise<Object>} Promise that resolves to an object with details about the deletion
+   */
+  deleteKeys(): Promise<DeleteKeysResult> {
+    return bridge.deleteKeys()
+  }
+
+  /**
+   * Prompts user with biometrics dialog using the passed in prompt message and
+   * returns promise that resolves to an object with object.signature,
+   * which is cryptographic signature of the payload
+   * @param {Object} createSignatureOptions
+   * @param {string} createSignatureOptions.promptMessage
+   * @param {string} createSignatureOptions.payload
+   * @returns {Promise<Object>}  Promise that resolves to an object cryptographic signature details
+   */
+  createSignature(createSignatureOptions: CreateSignatureOptions): Promise<CreateSignatureResult> {
+    createSignatureOptions.cancelButtonText = createSignatureOptions.cancelButtonText ?? 'Cancel'
+
+    return bridge.createSignature({
+      allowDeviceCredentials: this.allowDeviceCredentials,
+      ...createSignatureOptions
+    })
+  }
+
+  /**
+   * Prompts user with biometrics dialog using the passed in prompt message and
+   * returns promise that resolves to an object with object.success = true if the user passes,
+   * object.success = false if the user cancels, and rejects if anything fails
+   * @param {Object} simplePromptOptions
+   * @param {string} simplePromptOptions.promptMessage
+   * @param {string} simplePromptOptions.fallbackPromptMessage
+   * @returns {Promise<Object>}  Promise that resolves an object with details about the biometrics result
+   */
+  simplePrompt(simplePromptOptions: SimplePromptOptions): Promise<SimplePromptResult> {
+    simplePromptOptions.cancelButtonText = simplePromptOptions.cancelButtonText ?? 'Cancel'
+    simplePromptOptions.fallbackPromptMessage = simplePromptOptions.fallbackPromptMessage ?? 'Use Passcode'
+
+    return bridge.simplePrompt({
+      allowDeviceCredentials: this.allowDeviceCredentials,
+      ...simplePromptOptions
+    })
+  }
+}
+
+export default ReactNativeBiometrics

--- a/index.ts
+++ b/index.ts
@@ -52,26 +52,26 @@ interface SimplePromptResult {
   error?: string
 }
 
+/**
+ * Enum for touch id sensor type
+ */
+export const TouchID = 'TouchID'
+/**
+ * Enum for face id sensor type
+ */
+export const FaceID = 'FaceID'
+/**
+ * Enum for generic biometrics (this is the only value available on android)
+ */
+export const Biometrics = 'Biometrics'
+
+export const BiometryTypes = {
+  TouchID,
+  FaceID,
+  Biometrics
+}
+
 export module ReactNativeBiometricsLegacy {
-  /**
-   * Enum for touch id sensor type
-   */
-  export const TouchID = 'TouchID'
-  /**
-   * Enum for face id sensor type
-   */
-  export const FaceID = 'FaceID'
-  /**
-   * Enum for generic biometrics (this is the only value available on android)
-   */
-  export const Biometrics = 'Biometrics'
-
-  export const BiometryTypes = {
-    TouchID,
-    FaceID,
-    Biometrics
-  }
-
   /**
    * Returns promise that resolves to an object with object.biometryType = Biometrics | TouchID | FaceID
    * @returns {Promise<Object>} Promise that resolves to an object with details about biometrics available

--- a/index.ts
+++ b/index.ts
@@ -52,48 +52,32 @@ interface SimplePromptResult {
   error?: string
 }
 
-/**
- * Enum for touch id sensor type
- */
-export const TouchID = 'TouchID'
-/**
- * Enum for face id sensor type
- */
-export const FaceID = 'FaceID'
-/**
- * Enum for generic biometrics (this is the only value available on android)
- */
-export const Biometrics = 'Biometrics'
-
-export const BiometryTypes = {
-  TouchID,
-  FaceID,
-  Biometrics
-}
-
-class ReactNativeBiometrics {
-  allowDeviceCredentials = false
-
+export module ReactNativeBiometricsLegacy {
   /**
-   * Prompts user with biometrics dialog using the passed in prompt message and
-   * returns promise that resolves to an object with object.signature,
-   * which is cryptographic signature of the payload
-   * @param {Object} rnBiometricsOptions
-   * @param {boolean} rnBiometricsOptions.allowDeviceCredentials
+   * Enum for touch id sensor type
    */
-  constructor(rnBiometricsOptions?: RNBiometricsOptions) {
-    const allowDeviceCredentials = rnBiometricsOptions?.allowDeviceCredentials ?? false
-    this.allowDeviceCredentials = allowDeviceCredentials
+  export const TouchID = 'TouchID'
+  /**
+   * Enum for face id sensor type
+   */
+  export const FaceID = 'FaceID'
+  /**
+   * Enum for generic biometrics (this is the only value available on android)
+   */
+  export const Biometrics = 'Biometrics'
+
+  export const BiometryTypes = {
+    TouchID,
+    FaceID,
+    Biometrics
   }
 
   /**
    * Returns promise that resolves to an object with object.biometryType = Biometrics | TouchID | FaceID
    * @returns {Promise<Object>} Promise that resolves to an object with details about biometrics available
    */
-  isSensorAvailable(): Promise<IsSensorAvailableResult> {
-    return bridge.isSensorAvailable({
-      allowDeviceCredentials: this.allowDeviceCredentials
-    })
+  export function isSensorAvailable(): Promise<IsSensorAvailableResult> {
+    return new ReactNativeBiometrics().isSensorAvailable()
   }
 
   /**
@@ -101,10 +85,8 @@ class ReactNativeBiometrics {
    * an object with object.publicKey, which is the public key of the newly generated key pair
    * @returns {Promise<Object>}  Promise that resolves to object with details about the newly generated public key
    */
-  createKeys(): Promise<CreateKeysResult> {
-    return bridge.createKeys({
-      allowDeviceCredentials: this.allowDeviceCredentials
-    })
+  export function createKeys(): Promise<CreateKeysResult> {
+    return new ReactNativeBiometrics().createKeys()
   }
 
   /**
@@ -112,8 +94,8 @@ class ReactNativeBiometrics {
    * indicating if the keys were found to exist or not
    * @returns {Promise<Object>} Promise that resolves to object with details aobut the existence of keys
    */
-  biometricKeysExist(): Promise<BiometricKeysExistResult> {
-    return bridge.biometricKeysExist()
+  export function biometricKeysExist(): Promise<BiometricKeysExistResult> {
+    return new ReactNativeBiometrics().biometricKeysExist()
   }
 
   /**
@@ -121,8 +103,8 @@ class ReactNativeBiometrics {
    * indicating if the keys were properly deleted
    * @returns {Promise<Object>} Promise that resolves to an object with details about the deletion
    */
-  deleteKeys(): Promise<DeleteKeysResult> {
-    return bridge.deleteKeys()
+  export function deleteKeys(): Promise<DeleteKeysResult> {
+    return new ReactNativeBiometrics().deleteKeys()
   }
 
   /**
@@ -134,13 +116,8 @@ class ReactNativeBiometrics {
    * @param {string} createSignatureOptions.payload
    * @returns {Promise<Object>}  Promise that resolves to an object cryptographic signature details
    */
-  createSignature(createSignatureOptions: CreateSignatureOptions): Promise<CreateSignatureResult> {
-    createSignatureOptions.cancelButtonText = createSignatureOptions.cancelButtonText ?? 'Cancel'
-
-    return bridge.createSignature({
-      allowDeviceCredentials: this.allowDeviceCredentials,
-      ...createSignatureOptions
-    })
+  export function createSignature(createSignatureOptions: CreateSignatureOptions): Promise<CreateSignatureResult> {
+    return new ReactNativeBiometrics().createSignature(createSignatureOptions)
   }
 
   /**
@@ -152,15 +129,96 @@ class ReactNativeBiometrics {
    * @param {string} simplePromptOptions.fallbackPromptMessage
    * @returns {Promise<Object>}  Promise that resolves an object with details about the biometrics result
    */
-  simplePrompt(simplePromptOptions: SimplePromptOptions): Promise<SimplePromptResult> {
-    simplePromptOptions.cancelButtonText = simplePromptOptions.cancelButtonText ?? 'Cancel'
-    simplePromptOptions.fallbackPromptMessage = simplePromptOptions.fallbackPromptMessage ?? 'Use Passcode'
-
-    return bridge.simplePrompt({
-      allowDeviceCredentials: this.allowDeviceCredentials,
-      ...simplePromptOptions
-    })
+  export function simplePrompt(simplePromptOptions: SimplePromptOptions): Promise<SimplePromptResult> {
+    return new ReactNativeBiometrics().simplePrompt(simplePromptOptions)
   }
 }
 
-export default ReactNativeBiometrics
+export default class ReactNativeBiometrics {
+    allowDeviceCredentials = false
+
+    /**
+     * @param {Object} rnBiometricsOptions
+     * @param {boolean} rnBiometricsOptions.allowDeviceCredentials
+     */
+    constructor(rnBiometricsOptions?: RNBiometricsOptions) {
+      const allowDeviceCredentials = rnBiometricsOptions?.allowDeviceCredentials ?? false
+      this.allowDeviceCredentials = allowDeviceCredentials
+    }
+
+    /**
+     * Returns promise that resolves to an object with object.biometryType = Biometrics | TouchID | FaceID
+     * @returns {Promise<Object>} Promise that resolves to an object with details about biometrics available
+     */
+    isSensorAvailable(): Promise<IsSensorAvailableResult> {
+      return bridge.isSensorAvailable({
+        allowDeviceCredentials: this.allowDeviceCredentials
+      })
+    }
+
+    /**
+     * Creates a public private key pair,returns promise that resolves to
+     * an object with object.publicKey, which is the public key of the newly generated key pair
+     * @returns {Promise<Object>}  Promise that resolves to object with details about the newly generated public key
+     */
+    createKeys(): Promise<CreateKeysResult> {
+      return bridge.createKeys({
+        allowDeviceCredentials: this.allowDeviceCredentials
+      })
+    }
+
+    /**
+     * Returns promise that resolves to an object with object.keysExists = true | false
+     * indicating if the keys were found to exist or not
+     * @returns {Promise<Object>} Promise that resolves to object with details aobut the existence of keys
+     */
+    biometricKeysExist(): Promise<BiometricKeysExistResult> {
+      return bridge.biometricKeysExist()
+    }
+
+    /**
+     * Returns promise that resolves to an object with true | false
+     * indicating if the keys were properly deleted
+     * @returns {Promise<Object>} Promise that resolves to an object with details about the deletion
+     */
+    deleteKeys(): Promise<DeleteKeysResult> {
+      return bridge.deleteKeys()
+    }
+
+    /**
+     * Prompts user with biometrics dialog using the passed in prompt message and
+     * returns promise that resolves to an object with object.signature,
+     * which is cryptographic signature of the payload
+     * @param {Object} createSignatureOptions
+     * @param {string} createSignatureOptions.promptMessage
+     * @param {string} createSignatureOptions.payload
+     * @returns {Promise<Object>}  Promise that resolves to an object cryptographic signature details
+     */
+    createSignature(createSignatureOptions: CreateSignatureOptions): Promise<CreateSignatureResult> {
+      createSignatureOptions.cancelButtonText = createSignatureOptions.cancelButtonText ?? 'Cancel'
+
+      return bridge.createSignature({
+        allowDeviceCredentials: this.allowDeviceCredentials,
+        ...createSignatureOptions
+      })
+    }
+
+    /**
+     * Prompts user with biometrics dialog using the passed in prompt message and
+     * returns promise that resolves to an object with object.success = true if the user passes,
+     * object.success = false if the user cancels, and rejects if anything fails
+     * @param {Object} simplePromptOptions
+     * @param {string} simplePromptOptions.promptMessage
+     * @param {string} simplePromptOptions.fallbackPromptMessage
+     * @returns {Promise<Object>}  Promise that resolves an object with details about the biometrics result
+     */
+    simplePrompt(simplePromptOptions: SimplePromptOptions): Promise<SimplePromptResult> {
+      simplePromptOptions.cancelButtonText = simplePromptOptions.cancelButtonText ?? 'Cancel'
+      simplePromptOptions.fallbackPromptMessage = simplePromptOptions.fallbackPromptMessage ?? 'Use Passcode'
+
+      return bridge.simplePrompt({
+        allowDeviceCredentials: this.allowDeviceCredentials,
+        ...simplePromptOptions
+      })
+    }
+  }


### PR DESCRIPTION
The majority of the legacy functions required providing the option `allowDeviceCredentials` set to `true` in order to fully enable device credentials as a fallback/alternative. The problem with this approach is that all of the function calls had to ensure the same value was set, otherwise you might encounter issues with the biometric process. In order to ensure the same setting was used across all of the calls it seemed more straight forward to introduce a class for controlling the device credential state. The legacy API is still accessible and only requires a minor modification to any existing use cases. The one caveat is that the legacy API does NOT support the device feature. This can only be enabled when using the new API.
