### PR TITLE
Fix `allowDeviceAuthentication` failing on Android 31 and later

### DIFF
--- a/android/src/main/java/com/rnbiometrics/CreateSignatureCallback.java
+++ b/android/src/main/java/com/rnbiometrics/CreateSignatureCallback.java
@@ -1,24 +1,37 @@
 package com.rnbiometrics;
 
+import static com.rnbiometrics.ReactNativeBiometrics.biometricKeyAlias;
+
 import android.util.Base64;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import androidx.biometric.BiometricPrompt;
 
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
 
+import java.io.IOException;
+import java.security.InvalidKeyException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.PrivateKey;
 import java.security.Signature;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
 
 public class CreateSignatureCallback extends BiometricPrompt.AuthenticationCallback {
     private Promise promise;
     private String payload;
+    private boolean allowDeviceCredentials;
 
-    public CreateSignatureCallback(Promise promise, String payload) {
+    public CreateSignatureCallback(Promise promise, String payload, boolean allowDeviceCredentials) {
         super();
         this.promise = promise;
         this.payload = payload;
+        this.allowDeviceCredentials = allowDeviceCredentials;
     }
 
     @Override
@@ -39,8 +52,7 @@ public class CreateSignatureCallback extends BiometricPrompt.AuthenticationCallb
         super.onAuthenticationSucceeded(result);
 
         try {
-            BiometricPrompt.CryptoObject cryptoObject = result.getCryptoObject();
-            Signature cryptoSignature = cryptoObject.getSignature();
+            Signature cryptoSignature = getSignature(result);
             cryptoSignature.update(this.payload.getBytes());
             byte[] signed = cryptoSignature.sign();
             String signedString = Base64.encodeToString(signed, Base64.DEFAULT);
@@ -53,5 +65,20 @@ public class CreateSignatureCallback extends BiometricPrompt.AuthenticationCallb
         } catch (Exception e) {
             promise.reject("Error creating signature: " + e.getMessage(), "Error creating signature");
         }
+    }
+
+    @Nullable
+    private Signature getSignature(@NonNull BiometricPrompt.AuthenticationResult result) throws NoSuchAlgorithmException, KeyStoreException, CertificateException, IOException, UnrecoverableKeyException, InvalidKeyException {
+        if (this.allowDeviceCredentials) {
+            Signature signature = Signature.getInstance("SHA256withRSA");
+            KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
+            keyStore.load(null);
+            PrivateKey privateKey = (PrivateKey) keyStore.getKey(biometricKeyAlias, null);
+            signature.initSign(privateKey);
+            return signature;
+        }
+
+        BiometricPrompt.CryptoObject cryptoObject = result.getCryptoObject();
+        return cryptoObject.getSignature();
     }
 }


### PR DESCRIPTION
These changes are to attempt to address the issue outlined in #181. I was able to address the root issue where the `android.security.KeyStoreException: Key user not authenticated` is reported when attempting to sign with the private key. It  appears from this documentation that when using `BiometricPrompt.authenticate` we must use the form of the method that does not take `CryptoObject` as that implies the prompt will be used for Biometric authentication only (supporting documentation https://developer.android.com/training/sign-in/biometric-auth#biometric-or-lock-screen). 

After updating the implementation to not use the `CryptoObject` form of `BiometricPrompt.authenticate`. After enabling this new form of authentication for both Biometric and device authentication I did find that I was no longer able to verify the signature with my test backend. I was not able to resolve this issue and was hoping that someone else might take a look at my changes and be able to see what change may have caused this regression.