### PR TITLE
Android: adds Credentials to BiometryType

### DIFF
--- a/android/src/main/java/com/rnbiometrics/ReactNativeBiometrics.java
+++ b/android/src/main/java/com/rnbiometrics/ReactNativeBiometrics.java
@@ -1,5 +1,7 @@
 package com.rnbiometrics;
 
+import android.content.Context;
+import android.content.pm.PackageManager;
 import android.os.Build;
 import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyProperties;
@@ -54,12 +56,27 @@ public class ReactNativeBiometrics extends ReactContextBaseJavaModule {
                 boolean allowDeviceCredentials = params.getBoolean("allowDeviceCredentials");
                 ReactApplicationContext reactApplicationContext = getReactApplicationContext();
                 BiometricManager biometricManager = BiometricManager.from(reactApplicationContext);
+                PackageManager packageManager = reactApplicationContext.getPackageManager();
                 int canAuthenticate = biometricManager.canAuthenticate(getAllowedAuthenticators(false));
 
                 if (canAuthenticate == BiometricManager.BIOMETRIC_SUCCESS) {
                     WritableMap resultMap = new WritableNativeMap();
                     resultMap.putBoolean("available", true);
                     resultMap.putString("biometryType", "Biometrics");
+
+                    if (packageManager.hasSystemFeature(PackageManager.FEATURE_FINGERPRINT) == true) {
+                        resultMap.putString("biometryType", "Fingerprint");
+                    }
+                    
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                        if (packageManager.hasSystemFeature(PackageManager.FEATURE_FACE) == true) {
+                            resultMap.putString("biometryType", "Face");
+                        }
+                        if (packageManager.hasSystemFeature(PackageManager.FEATURE_IRIS) == true) {
+                            resultMap.putString("biometryType", "Iris");
+                        }
+                    }
+
                     promise.resolve(resultMap);
                 } else if (allowDeviceCredentials) {
                     int canAuthenticateCredentials = biometricManager.canAuthenticate(getAllowedAuthenticators(allowDeviceCredentials));
@@ -149,6 +166,10 @@ public class ReactNativeBiometrics extends ReactContextBaseJavaModule {
 
     private boolean isCurrentSDKMarshmallowOrLater() {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M;
+    }
+
+    private boolean isCurrentSDKSnowConeOrLater() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.S;
     }
 
     @ReactMethod

--- a/android/src/main/java/com/rnbiometrics/ReactNativeBiometrics.java
+++ b/android/src/main/java/com/rnbiometrics/ReactNativeBiometrics.java
@@ -67,7 +67,7 @@ public class ReactNativeBiometrics extends ReactContextBaseJavaModule {
                     if (packageManager.hasSystemFeature(PackageManager.FEATURE_FINGERPRINT) == true) {
                         resultMap.putString("biometryType", "Fingerprint");
                     }
-                    
+
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                         if (packageManager.hasSystemFeature(PackageManager.FEATURE_FACE) == true) {
                             resultMap.putString("biometryType", "Face");
@@ -120,7 +120,7 @@ public class ReactNativeBiometrics extends ReactContextBaseJavaModule {
                             break;
                     }
 
-                    promise.resolve(resultMap); 
+                    promise.resolve(resultMap);
                 }
             } else {
                 WritableMap resultMap = new WritableNativeMap();

--- a/android/src/main/java/com/rnbiometrics/ReactNativeBiometrics.java
+++ b/android/src/main/java/com/rnbiometrics/ReactNativeBiometrics.java
@@ -54,13 +54,39 @@ public class ReactNativeBiometrics extends ReactContextBaseJavaModule {
                 boolean allowDeviceCredentials = params.getBoolean("allowDeviceCredentials");
                 ReactApplicationContext reactApplicationContext = getReactApplicationContext();
                 BiometricManager biometricManager = BiometricManager.from(reactApplicationContext);
-                int canAuthenticate = biometricManager.canAuthenticate(getAllowedAuthenticators(allowDeviceCredentials));
+                int canAuthenticate = biometricManager.canAuthenticate(getAllowedAuthenticators(false));
 
                 if (canAuthenticate == BiometricManager.BIOMETRIC_SUCCESS) {
                     WritableMap resultMap = new WritableNativeMap();
                     resultMap.putBoolean("available", true);
                     resultMap.putString("biometryType", "Biometrics");
                     promise.resolve(resultMap);
+                } else if (allowDeviceCredentials) {
+                    int canAuthenticateCredentials = biometricManager.canAuthenticate(getAllowedAuthenticators(allowDeviceCredentials));
+
+                    if (canAuthenticateCredentials == BiometricManager.BIOMETRIC_SUCCESS) {
+                        WritableMap resultMap = new WritableNativeMap();
+                        resultMap.putBoolean("available", true);
+                        resultMap.putString("biometryType", "Credentials");
+                        promise.resolve(resultMap);
+                    } else {
+                        WritableMap resultMap = new WritableNativeMap();
+                        resultMap.putBoolean("available", false);
+
+                        switch (canAuthenticateCredentials) {
+                            case BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE:
+                                resultMap.putString("error", "BIOMETRIC_ERROR_NO_HARDWARE");
+                                break;
+                            case BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE:
+                                resultMap.putString("error", "BIOMETRIC_ERROR_HW_UNAVAILABLE");
+                                break;
+                            case BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED:
+                                resultMap.putString("error", "BIOMETRIC_ERROR_NONE_ENROLLED");
+                                break;
+                        }
+
+                        promise.resolve(resultMap);
+                    }
                 } else {
                     WritableMap resultMap = new WritableNativeMap();
                     resultMap.putBoolean("available", false);
@@ -77,7 +103,7 @@ public class ReactNativeBiometrics extends ReactContextBaseJavaModule {
                             break;
                     }
 
-                    promise.resolve(resultMap);
+                    promise.resolve(resultMap); 
                 }
             } else {
                 WritableMap resultMap = new WritableNativeMap();

--- a/android/src/main/java/com/rnbiometrics/ReactNativeBiometrics.java
+++ b/android/src/main/java/com/rnbiometrics/ReactNativeBiometrics.java
@@ -160,10 +160,6 @@ public class ReactNativeBiometrics extends ReactContextBaseJavaModule {
         return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M;
     }
 
-    private boolean isCurrentSDKSnowConeOrLater() {
-        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.S;
-    }
-
     @ReactMethod
     public void deleteKeys(Promise promise) {
         if (doesBiometricKeyExist()) {

--- a/android/src/main/java/com/rnbiometrics/ReactNativeBiometrics.java
+++ b/android/src/main/java/com/rnbiometrics/ReactNativeBiometrics.java
@@ -68,14 +68,6 @@ public class ReactNativeBiometrics extends ReactContextBaseJavaModule {
                         resultMap.putString("biometryType", "Fingerprint");
                     }
 
-                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                        if (packageManager.hasSystemFeature(PackageManager.FEATURE_FACE) == true) {
-                            resultMap.putString("biometryType", "Face");
-                        }
-                        if (packageManager.hasSystemFeature(PackageManager.FEATURE_IRIS) == true) {
-                            resultMap.putString("biometryType", "Iris");
-                        }
-                    }
 
                     promise.resolve(resultMap);
                 } else if (allowDeviceCredentials) {

--- a/android/src/main/java/com/rnbiometrics/ReactNativeBiometrics.java
+++ b/android/src/main/java/com/rnbiometrics/ReactNativeBiometrics.java
@@ -68,7 +68,6 @@ public class ReactNativeBiometrics extends ReactContextBaseJavaModule {
                         resultMap.putString("biometryType", "Fingerprint");
                     }
 
-
                     promise.resolve(resultMap);
                 } else if (allowDeviceCredentials) {
                     int canAuthenticateCredentials = biometricManager.canAuthenticate(getAllowedAuthenticators(true));
@@ -77,40 +76,19 @@ public class ReactNativeBiometrics extends ReactContextBaseJavaModule {
                         WritableMap resultMap = new WritableNativeMap();
                         resultMap.putBoolean("available", true);
                         resultMap.putString("biometryType", "Credentials");
+                        
                         promise.resolve(resultMap);
                     } else {
                         WritableMap resultMap = new WritableNativeMap();
                         resultMap.putBoolean("available", false);
-
-                        switch (canAuthenticateCredentials) {
-                            case BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE:
-                                resultMap.putString("error", "BIOMETRIC_ERROR_NO_HARDWARE");
-                                break;
-                            case BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE:
-                                resultMap.putString("error", "BIOMETRIC_ERROR_HW_UNAVAILABLE");
-                                break;
-                            case BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED:
-                                resultMap.putString("error", "BIOMETRIC_ERROR_NONE_ENROLLED");
-                                break;
-                        }
+                        resultMap.putString("error", parseError(canAuthenticateCredentials));
 
                         promise.resolve(resultMap);
                     }
                 } else {
                     WritableMap resultMap = new WritableNativeMap();
                     resultMap.putBoolean("available", false);
-
-                    switch (canAuthenticate) {
-                        case BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE:
-                            resultMap.putString("error", "BIOMETRIC_ERROR_NO_HARDWARE");
-                            break;
-                        case BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE:
-                            resultMap.putString("error", "BIOMETRIC_ERROR_HW_UNAVAILABLE");
-                            break;
-                        case BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED:
-                            resultMap.putString("error", "BIOMETRIC_ERROR_NONE_ENROLLED");
-                            break;
-                    }
+                    resultMap.putString("error", parseError(canAuthenticate));
 
                     promise.resolve(resultMap);
                 }
@@ -121,8 +99,27 @@ public class ReactNativeBiometrics extends ReactContextBaseJavaModule {
                 promise.resolve(resultMap);
             }
         } catch (Exception e) {
-            promise.reject("Error detecting biometrics availability: " + e.getMessage(), "Error detecting biometrics availability: " + e.getMessage());
+            promise.reject("Error detecting biometrics availability: " + e.getMessage(),
+                    "Error detecting biometrics availability: " + e.getMessage());
         }
+    }
+
+    private String parseError(final int authenticationResult) {
+        String message = "";
+
+        switch (authenticationResult) {
+            case BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE:
+                message = "BIOMETRIC_ERROR_NO_HARDWARE";
+                break;
+            case BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE:
+                message = "BIOMETRIC_ERROR_HW_UNAVAILABLE";
+                break;
+            case BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED:
+                message = "BIOMETRIC_ERROR_NONE_ENROLLED";
+                break;
+        }
+
+        return message;
     }
 
     @ReactMethod

--- a/android/src/main/java/com/rnbiometrics/ReactNativeBiometrics.java
+++ b/android/src/main/java/com/rnbiometrics/ReactNativeBiometrics.java
@@ -71,7 +71,7 @@ public class ReactNativeBiometrics extends ReactContextBaseJavaModule {
 
                     promise.resolve(resultMap);
                 } else if (allowDeviceCredentials) {
-                    int canAuthenticateCredentials = biometricManager.canAuthenticate(getAllowedAuthenticators(allowDeviceCredentials));
+                    int canAuthenticateCredentials = biometricManager.canAuthenticate(getAllowedAuthenticators(true));
 
                     if (canAuthenticateCredentials == BiometricManager.BIOMETRIC_SUCCESS) {
                         WritableMap resultMap = new WritableNativeMap();

--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,7 @@ const { ReactNativeBiometrics: bridge } = NativeModules
  * Type alias for possible biometry types
  */
 export type BiometryTypeIOS = 'TouchID' | 'FaceID'
-export type BiometryTypeAndroid ='Fingerprint' | 'Face' | 'Iris'| 'Biometrics' | 'Credentials'
+export type BiometryTypeAndroid ='Fingerprint' | 'Biometrics' | 'Credentials'
 export type BiometryType = BiometryTypeIOS | BiometryTypeAndroid
 
 interface RNBiometricsOptions {
@@ -70,10 +70,8 @@ export const FaceID = 'FaceID'
 /**
  * Enum for generic biometrics (this is the only value available on android)
  */
-export const Fingerprint = 'Fingerprint'
-export const Face = 'Face'
-export const Iris = 'Iris'
 export const Biometrics = 'Biometrics'
+export const Fingerprint = 'Fingerprint'
 export const Credentials = 'Credentials'
 
 export const BiometryTypes = {
@@ -81,8 +79,6 @@ export const BiometryTypes = {
   FaceID,
   Biometrics,
   Fingerprint,
-  Face,
-  Iris,
   Credentials
 }
 

--- a/index.ts
+++ b/index.ts
@@ -5,7 +5,9 @@ const { ReactNativeBiometrics: bridge } = NativeModules
 /**
  * Type alias for possible biometry types
  */
-export type BiometryType = 'TouchID' | 'FaceID' | 'Biometrics' | 'Credentials'
+export type BiometryTypeIOS = 'TouchID' | 'FaceID'
+export type BiometryTypeAndroid ='Fingerprint' | 'Face' | 'Iris'| 'Biometrics' | 'Credentials'
+export type BiometryType = BiometryTypeIOS | BiometryTypeAndroid
 
 interface RNBiometricsOptions {
   allowDeviceCredentials?: boolean
@@ -68,6 +70,9 @@ export const FaceID = 'FaceID'
 /**
  * Enum for generic biometrics (this is the only value available on android)
  */
+export const Fingerprint = 'Fingerprint'
+export const Face = 'Face'
+export const Iris = 'Iris'
 export const Biometrics = 'Biometrics'
 export const Credentials = 'Credentials'
 
@@ -75,6 +80,9 @@ export const BiometryTypes = {
   TouchID,
   FaceID,
   Biometrics,
+  Fingerprint,
+  Face,
+  Iris,
   Credentials
 }
 
@@ -83,7 +91,7 @@ export module ReactNativeBiometricsLegacy {
    * Returns promise that resolves to an object with object.biometryType = Biometrics | TouchID | FaceID | Credentials
    * @returns {Promise<Object>} Promise that resolves to an object with details about biometrics available
    */
-  export function isSensorAvailable(params: isSensorAvailable): Promise<IsSensorAvailableResult> {
+   export function isSensorAvailable(params: isSensorAvailable): Promise<IsSensorAvailableResult> {
     return new ReactNativeBiometrics().isSensorAvailable(params)
   }
 
@@ -225,7 +233,7 @@ export default class ReactNativeBiometrics {
       simplePromptOptions.fallbackPromptMessage = simplePromptOptions.fallbackPromptMessage ?? 'Use Passcode'
 
       return bridge.simplePrompt({
-        allowDeviceCredentials: simplePromptOptions.allowDeviceCredentials ??  this.allowDeviceCredentials,
+        allowDeviceCredentials: simplePromptOptions.allowDeviceCredentials ?? this.allowDeviceCredentials,
         ...simplePromptOptions
       })
     }

--- a/index.ts
+++ b/index.ts
@@ -5,9 +5,13 @@ const { ReactNativeBiometrics: bridge } = NativeModules
 /**
  * Type alias for possible biometry types
  */
-export type BiometryType = 'TouchID' | 'FaceID' | 'Biometrics'
+export type BiometryType = 'TouchID' | 'FaceID' | 'Biometrics' | 'Credentials'
 
 interface RNBiometricsOptions {
+  allowDeviceCredentials?: boolean
+}
+
+interface isSensorAvailable {
   allowDeviceCredentials?: boolean
 }
 
@@ -45,6 +49,7 @@ interface SimplePromptOptions {
   promptMessage: string
   fallbackPromptMessage?: string
   cancelButtonText?: string
+  allowDeviceCredentials?: boolean
 }
 
 interface SimplePromptResult {
@@ -64,20 +69,22 @@ export const FaceID = 'FaceID'
  * Enum for generic biometrics (this is the only value available on android)
  */
 export const Biometrics = 'Biometrics'
+export const Credentials = 'Credentials'
 
 export const BiometryTypes = {
   TouchID,
   FaceID,
-  Biometrics
+  Biometrics,
+  Credentials
 }
 
 export module ReactNativeBiometricsLegacy {
   /**
-   * Returns promise that resolves to an object with object.biometryType = Biometrics | TouchID | FaceID
+   * Returns promise that resolves to an object with object.biometryType = Biometrics | TouchID | FaceID | Credentials
    * @returns {Promise<Object>} Promise that resolves to an object with details about biometrics available
    */
-  export function isSensorAvailable(): Promise<IsSensorAvailableResult> {
-    return new ReactNativeBiometrics().isSensorAvailable()
+  export function isSensorAvailable(params: isSensorAvailable): Promise<IsSensorAvailableResult> {
+    return new ReactNativeBiometrics().isSensorAvailable(params)
   }
 
   /**
@@ -127,6 +134,7 @@ export module ReactNativeBiometricsLegacy {
    * @param {Object} simplePromptOptions
    * @param {string} simplePromptOptions.promptMessage
    * @param {string} simplePromptOptions.fallbackPromptMessage
+   * @param {boolean} simplePromptOptions.allowDeviceCredentials
    * @returns {Promise<Object>}  Promise that resolves an object with details about the biometrics result
    */
   export function simplePrompt(simplePromptOptions: SimplePromptOptions): Promise<SimplePromptResult> {
@@ -150,9 +158,9 @@ export default class ReactNativeBiometrics {
      * Returns promise that resolves to an object with object.biometryType = Biometrics | TouchID | FaceID
      * @returns {Promise<Object>} Promise that resolves to an object with details about biometrics available
      */
-    isSensorAvailable(): Promise<IsSensorAvailableResult> {
+    isSensorAvailable(params?: isSensorAvailable): Promise<IsSensorAvailableResult> {
       return bridge.isSensorAvailable({
-        allowDeviceCredentials: this.allowDeviceCredentials
+        allowDeviceCredentials: params?.allowDeviceCredentials ?? this.allowDeviceCredentials
       })
     }
 
@@ -217,7 +225,7 @@ export default class ReactNativeBiometrics {
       simplePromptOptions.fallbackPromptMessage = simplePromptOptions.fallbackPromptMessage ?? 'Use Passcode'
 
       return bridge.simplePrompt({
-        allowDeviceCredentials: this.allowDeviceCredentials,
+        allowDeviceCredentials: simplePromptOptions.allowDeviceCredentials ??  this.allowDeviceCredentials,
         ...simplePromptOptions
       })
     }

--- a/ios/ReactNativeBiometrics.m
+++ b/ios/ReactNativeBiometrics.m
@@ -16,14 +16,10 @@ RCT_EXPORT_MODULE(ReactNativeBiometrics);
 RCT_EXPORT_METHOD(isSensorAvailable: (NSDictionary *)params resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   LAContext *context = [[LAContext alloc] init];
   NSError *la_error = nil;
+  NSError *la_errorWithCredentials = nil;
   BOOL allowDeviceCredentials = [RCTConvert BOOL:params[@"allowDeviceCredentials"]];
-  LAPolicy laPolicy = LAPolicyDeviceOwnerAuthenticationWithBiometrics;
 
-  if (allowDeviceCredentials == TRUE) {
-    laPolicy = LAPolicyDeviceOwnerAuthentication;
-  }
-
-  BOOL canEvaluatePolicy = [context canEvaluatePolicy:laPolicy error:&la_error];
+  BOOL canEvaluatePolicy = [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthenticationWithBiometrics error:&la_error];
 
   if (canEvaluatePolicy) {
     NSString *biometryType = [self getBiometryType:context];
@@ -34,13 +30,23 @@ RCT_EXPORT_METHOD(isSensorAvailable: (NSDictionary *)params resolver:(RCTPromise
 
     resolve(result);
   } else {
-    NSString *errorMessage = [NSString stringWithFormat:@"%@", la_error];
-    NSDictionary *result = @{
-      @"available": @(NO),
-      @"error": errorMessage
-    };
+    if (allowDeviceCredentials == TRUE) {
+      BOOL canEvaluatePolicy = [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&la_errorWithCredentials];
+      NSString *biometryType = [self getBiometryType:context];
+      NSDictionary *result = @{
+        @"available": @(YES),
+        @"biometryType": "Credentials"
+      };
 
-    resolve(result);
+      resolve(result);
+    } else {
+      NSString *errorMessage = [NSString stringWithFormat:@"%@", la_error];
+      NSDictionary *result = @{
+        @"available": @(NO),
+        @"error": errorMessage
+      };
+
+      resolve(result);
   }
 }
 

--- a/ios/ReactNativeBiometrics.m
+++ b/ios/ReactNativeBiometrics.m
@@ -29,16 +29,24 @@ RCT_EXPORT_METHOD(isSensorAvailable: (NSDictionary *)params resolver:(RCTPromise
     };
 
     resolve(result);
-  } else {
-    if (allowDeviceCredentials == TRUE) {
-      BOOL canEvaluatePolicy = [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&la_errorWithCredentials];
-      NSString *biometryType = [self getBiometryType:context];
-      NSDictionary *result = @{
-        @"available": @(YES),
-        @"biometryType": "Credentials"
-      };
+  } else if (allowDeviceCredentials == TRUE)  {
+      BOOL canEvaluatePolicyWithCredentials = [context canEvaluatePolicy:LAPolicyDeviceOwnerAuthentication error:&la_errorWithCredentials];
+      if(canEvaluatePolicyWithCredentials == TRUE) {
+        NSDictionary *result = @{
+          @"available": @(YES),
+          @"biometryType": @"Credentials"
+        };
 
-      resolve(result);
+        resolve(result);
+      } else {
+        NSString *errorMessage = [NSString stringWithFormat:@"%@", la_errorWithCredentials];
+        NSDictionary *result = @{
+          @"available": @(NO),
+          @"error": errorMessage
+        };
+
+        resolve(result);
+      }
     } else {
       NSString *errorMessage = [NSString stringWithFormat:@"%@", la_error];
       NSDictionary *result = @{


### PR DESCRIPTION
- Allow passing in `allowDeviceCredentials` to `isSensorAvailable` and `simplePrompt`
- Adds `Credentials` BiometryType to differentiate between https://developer.android.com/reference/androidx/biometric/BiometricManager.Authenticators#BIOMETRIC_STRONG() and https://developer.android.com/reference/androidx/biometric/BiometricManager.Authenticators#DEVICE_CREDENTIAL()
- Android: use `android.content.pm.PackageManager` to check if it is `Fingerprint`