### PR TITLE
Adds missing error message case

### DIFF
--- a/android/src/main/java/com/rnbiometrics/ReactNativeBiometrics.java
+++ b/android/src/main/java/com/rnbiometrics/ReactNativeBiometrics.java
@@ -75,6 +75,9 @@ public class ReactNativeBiometrics extends ReactContextBaseJavaModule {
                         case BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED:
                             resultMap.putString("error", "BIOMETRIC_ERROR_NONE_ENROLLED");
                             break;
+                        case BiometricManager.BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED:
+                            resultMap.putString("error", "BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED");
+                            break; 
                     }
 
                     promise.resolve(resultMap);


### PR DESCRIPTION
This PR adds the error message case BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED for canAuthenticate result handling.

https://developer.android.com/reference/android/hardware/biometrics/BiometricManager#canAuthenticate()