### PR TITLE
Added example of server side signature verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,14 +296,15 @@ const crypto = require('crypto');
 async function veryfySignature(publicKey, signature, payload) {
   const cryptoKey = await crypto.subtle.importKey('spki',
     Buffer.from(publicKey, 'base64'),
-    { name: 'RSASSA-PKCS1-v1_5', hash: "SHA256" },
+    { name: 'RSASSA-PKCS1-v1_5', hash: "SHA-256" },
     true, ['verify']
   );
 
   const verify = crypto.createVerify('SHA256');
-  verify.write(payload).end();
+  verify.write(payload);
+  verify.end();
 
-  return verify.verify(cryptoKey, Buffer.from(signature, 'base64'), 'hex');
+  return verify.verify(crypto.KeyObject.from(cryptoKey), signature, 'base64')
 }
 
 ```

--- a/README.md
+++ b/README.md
@@ -288,6 +288,26 @@ rnBiometrics.createSignature({
   })
 ```
 
+__Node.js example of server-side signature verification__
+
+```js
+const crypto = require('crypto');
+
+async function veryfySignature(publicKey, signature, payload) {
+  const cryptoKey = await crypto.subtle.importKey('spki',
+    Buffer.from(publicKey, 'base64'),
+    { name: 'RSASSA-PKCS1-v1_5', hash: "SHA256" },
+    true, ['verify']
+  );
+
+  const verify = crypto.createVerify('SHA256');
+  verify.write(payload).end();
+
+  return verify.verify(cryptoKey, Buffer.from(signature, 'base64'), 'hex');
+}
+
+```
+
 ### simplePrompt(options)
 
 Prompts the user for their fingerprint or face id. Returns a `Promise` that resolves if the user provides a valid biometrics or cancel the prompt, otherwise the promise rejects.


### PR DESCRIPTION
Just small example to help some implementing server side signature verification, because it's not obvious thing to deal with key formats, names, hashes, etc. 