### PR TITLE
Native error codes when an error occurs

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ __Result Object__
 | available | bool | A boolean indicating if biometrics is available or not |
 | biometryType | string | A string indicating what type of biometrics is available. `TouchID`, `FaceID`, `Biometrics`, or `undefined` if biometrics is not available. |
 | error | string | An error message indicating why biometrics may not be available. `undefined` if there is no error. |
+| errorCode | `IsSensorAvailableErrorCode` _(Android)_ <br> number _(iOS)_ | The native error code indicating why biometrics may not be available. |
 
 __Example__
 
@@ -263,6 +264,7 @@ __Result Object__
 | success | bool | A boolean indicating if the process was successful, `false` if the users cancels the biometrics prompt |
 | signature | string | A base64 encoded string representing the signature. `undefined` if the process was not successful. |
 | error | string | An error message indicating reasons why signature creation failed. `undefined` if there is no error. |
+| errorCode | `PromptErrorCode` _(Android)_ <br> number _(iOS)_ | The native error code indicating reasons why signature creation failed. |
 
 __Example__
 
@@ -308,6 +310,7 @@ __Result Object__
 | --- | --- | --- |
 | success | bool | A boolean indicating if the biometric prompt succeeded, `false` if the users cancels the biometrics prompt |
 | error | string | An error message indicating why the biometric prompt failed. `undefined` if there is no error. |
+| errorCode | `PromptErrorCode` _(Android)_ <br> number _(iOS)_ | The native error code indicating why the biometric prompt failed. |
 
 __Example__
 

--- a/android/src/main/java/com/rnbiometrics/CreateSignatureCallback.java
+++ b/android/src/main/java/com/rnbiometrics/CreateSignatureCallback.java
@@ -24,14 +24,15 @@ public class CreateSignatureCallback extends BiometricPrompt.AuthenticationCallb
     @Override
     public void onAuthenticationError(int errorCode, @NonNull CharSequence errString) {
         super.onAuthenticationError(errorCode, errString);
-        if (errorCode == BiometricPrompt.ERROR_NEGATIVE_BUTTON || errorCode == BiometricPrompt.ERROR_USER_CANCELED ) {
-            WritableMap resultMap = new WritableNativeMap();
-            resultMap.putBoolean("success", false);
+        WritableMap resultMap = new WritableNativeMap();
+        resultMap.putBoolean("success", false);
+        resultMap.putInt("errorCode", errorCode);
+        if (errorCode == BiometricPrompt.ERROR_NEGATIVE_BUTTON || errorCode == BiometricPrompt.ERROR_USER_CANCELED) {
             resultMap.putString("error", "User cancellation");
-            this.promise.resolve(resultMap);
         } else {
-            this.promise.reject(errString.toString(), errString.toString());
+            resultMap.putString("error", errString.toString());
         }
+        this.promise.resolve(resultMap);
     }
 
     @Override

--- a/android/src/main/java/com/rnbiometrics/ReactNativeBiometrics.java
+++ b/android/src/main/java/com/rnbiometrics/ReactNativeBiometrics.java
@@ -64,6 +64,7 @@ public class ReactNativeBiometrics extends ReactContextBaseJavaModule {
                 } else {
                     WritableMap resultMap = new WritableNativeMap();
                     resultMap.putBoolean("available", false);
+                    resultMap.putInt("errorCode", canAuthenticate);
 
                     switch (canAuthenticate) {
                         case BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE:

--- a/android/src/main/java/com/rnbiometrics/SimplePromptCallback.java
+++ b/android/src/main/java/com/rnbiometrics/SimplePromptCallback.java
@@ -18,14 +18,15 @@ public class SimplePromptCallback extends BiometricPrompt.AuthenticationCallback
     @Override
     public void onAuthenticationError(int errorCode, @NonNull CharSequence errString) {
         super.onAuthenticationError(errorCode, errString);
+        WritableMap resultMap = new WritableNativeMap();
+        resultMap.putBoolean("success", false);
+        resultMap.putInt("errorCode", errorCode);
         if (errorCode == BiometricPrompt.ERROR_NEGATIVE_BUTTON || errorCode == BiometricPrompt.ERROR_USER_CANCELED) {
-            WritableMap resultMap = new WritableNativeMap();
-            resultMap.putBoolean("success", false);
             resultMap.putString("error", "User cancellation");
-            this.promise.resolve(resultMap);
         } else {
-            this.promise.reject(errString.toString(), errString.toString());
+            resultMap.putString("error", errString.toString());
         }
+        this.promise.resolve(resultMap);
     }
 
     @Override

--- a/index.ts
+++ b/index.ts
@@ -8,9 +8,10 @@ const { ReactNativeBiometrics: bridge } = NativeModules
 export type BiometryType = 'TouchID' | 'FaceID' | 'Biometrics'
 
 /**
+ * Only for Android
  * https://developer.android.com/reference/androidx/biometric/BiometricManager#constants_1
  */
-export enum AndroidCanAuthenticateErrorCode {
+export enum IsSensorAvailableErrorCode {
   BIOMETRIC_ERROR_HW_UNAVAILABLE = 1,
   BIOMETRIC_ERROR_NONE_ENROLLED = 11,
   BIOMETRIC_ERROR_NO_HARDWARE = 12,
@@ -20,9 +21,10 @@ export enum AndroidCanAuthenticateErrorCode {
 }
 
 /**
+ * Only for Android
  * https://developer.android.com/reference/androidx/biometric/BiometricPrompt#constants_1
  */
-export enum AndroidPromptErrorCode {
+export enum PromptErrorCode {
   ERROR_CANCELED = 5,
   ERROR_HW_NOT_PRESENT = 12,
   ERROR_HW_UNAVAILABLE = 1,
@@ -48,7 +50,7 @@ interface IsSensorAvailableResult {
   available: boolean
   biometryType?: BiometryType
   error?: string
-  errorCode?: AndroidCanAuthenticateErrorCode | number
+  errorCode?: IsSensorAvailableErrorCode | number
 }
 
 interface CreateKeysResult {
@@ -73,7 +75,7 @@ interface CreateSignatureResult {
   success: boolean
   signature?: string
   error?: string
-  errorCode?: AndroidPromptErrorCode | number
+  errorCode?: PromptErrorCode | number
 }
 
 interface SimplePromptOptions {
@@ -85,7 +87,7 @@ interface SimplePromptOptions {
 interface SimplePromptResult {
   success: boolean
   error?: string
-  errorCode?: AndroidPromptErrorCode | number
+  errorCode?: PromptErrorCode | number
 }
 
 /**

--- a/index.ts
+++ b/index.ts
@@ -48,7 +48,7 @@ interface IsSensorAvailableResult {
   available: boolean
   biometryType?: BiometryType
   error?: string
-  errorCode?: AndroidCanAuthenticateErrorCode
+  errorCode?: AndroidCanAuthenticateErrorCode | number
 }
 
 interface CreateKeysResult {
@@ -73,7 +73,7 @@ interface CreateSignatureResult {
   success: boolean
   signature?: string
   error?: string
-  errorCode?: AndroidPromptErrorCode
+  errorCode?: AndroidPromptErrorCode | number
 }
 
 interface SimplePromptOptions {
@@ -85,7 +85,7 @@ interface SimplePromptOptions {
 interface SimplePromptResult {
   success: boolean
   error?: string
-  errorCode?: AndroidPromptErrorCode
+  errorCode?: AndroidPromptErrorCode | number
 }
 
 /**

--- a/index.ts
+++ b/index.ts
@@ -7,6 +7,39 @@ const { ReactNativeBiometrics: bridge } = NativeModules
  */
 export type BiometryType = 'TouchID' | 'FaceID' | 'Biometrics'
 
+/**
+ * https://developer.android.com/reference/androidx/biometric/BiometricManager#constants_1
+ */
+export enum AndroidCanAuthenticateErrorCode {
+  BIOMETRIC_ERROR_HW_UNAVAILABLE = 1,
+  BIOMETRIC_ERROR_NONE_ENROLLED = 11,
+  BIOMETRIC_ERROR_NO_HARDWARE = 12,
+  BIOMETRIC_ERROR_SECURITY_UPDATE_REQUIRED = 15,
+  BIOMETRIC_ERROR_UNSUPPORTED = -2,
+  BIOMETRIC_STATUS_UNKNOWN = -1
+}
+
+/**
+ * https://developer.android.com/reference/androidx/biometric/BiometricPrompt#constants_1
+ */
+export enum AndroidPromptErrorCode {
+  ERROR_CANCELED = 5,
+  ERROR_HW_NOT_PRESENT = 12,
+  ERROR_HW_UNAVAILABLE = 1,
+  ERROR_LOCKOUT = 7,
+  ERROR_LOCKOUT_PERMANENT = 9,
+  ERROR_MORE_OPTIONS_BUTTON = 16,
+  ERROR_NEGATIVE_BUTTON = 13,
+  ERROR_NO_BIOMETRICS = 11,
+  ERROR_NO_DEVICE_CREDENTIAL = 14,
+  ERROR_NO_SPACE = 4,
+  ERROR_SECURITY_UPDATE_REQUIRED = 15,
+  ERROR_TIMEOUT = 3,
+  ERROR_UNABLE_TO_PROCESS = 2,
+  ERROR_USER_CANCELED = 10,
+  ERROR_VENDOR = 8
+}
+
 interface RNBiometricsOptions {
   allowDeviceCredentials?: boolean
 }
@@ -15,6 +48,7 @@ interface IsSensorAvailableResult {
   available: boolean
   biometryType?: BiometryType
   error?: string
+  errorCode?: AndroidCanAuthenticateErrorCode
 }
 
 interface CreateKeysResult {
@@ -39,6 +73,7 @@ interface CreateSignatureResult {
   success: boolean
   signature?: string
   error?: string
+  errorCode?: AndroidPromptErrorCode
 }
 
 interface SimplePromptOptions {
@@ -50,6 +85,7 @@ interface SimplePromptOptions {
 interface SimplePromptResult {
   success: boolean
   error?: string
+  errorCode?: AndroidPromptErrorCode
 }
 
 /**

--- a/ios/ReactNativeBiometrics.m
+++ b/ios/ReactNativeBiometrics.m
@@ -37,7 +37,8 @@ RCT_EXPORT_METHOD(isSensorAvailable: (NSDictionary *)params resolver:(RCTPromise
     NSString *errorMessage = [NSString stringWithFormat:@"%@", la_error];
     NSDictionary *result = @{
       @"available": @(NO),
-      @"error": errorMessage
+      @"error": errorMessage,
+      @"errorCode": @(la_error.code)
     };
 
     resolve(result);
@@ -155,12 +156,18 @@ RCT_EXPORT_METHOD(createSignature: (NSDictionary *)params resolver:(RCTPromiseRe
       } else if (error.code == errSecUserCanceled) {
         NSDictionary *result = @{
           @"success": @(NO),
-          @"error": @"User cancellation"
+          @"error": @"User cancellation",
+          @"errorCode": @(error.code)
         };
         resolve(result);
       } else {
         NSString *message = [NSString stringWithFormat:@"Signature error: %@", error];
-        reject(@"signature_error", message, nil);
+        NSDictionary *result = @{
+          @"success": @(NO),
+          @"error": message,
+          @"errorCode": @(error.code)
+        };
+        resolve(result);
       }
     } else {
       NSString *message = [NSString stringWithFormat:@"Key not found: %@",[self keychainErrorToString:status]];
@@ -194,12 +201,18 @@ RCT_EXPORT_METHOD(simplePrompt: (NSDictionary *)params resolver:(RCTPromiseResol
       } else if (biometricError.code == LAErrorUserCancel) {
         NSDictionary *result = @{
           @"success": @(NO),
-          @"error": @"User cancellation"
+          @"error": @"User cancellation",
+          @"errorCode": @(biometricError.code)
         };
         resolve(result);
       } else {
         NSString *message = [NSString stringWithFormat:@"%@", biometricError];
-        reject(@"biometric_error", message, nil);
+        NSDictionary *result = @{
+          @"success": @(NO),
+          @"error": message,
+          @"errorCode": @(biometricError.code)
+        };
+        resolve(result);
       }
     }];
   });


### PR DESCRIPTION
Send the native error code to the JS side.
For android, the code values are already available (hence the newly created enums).
However, on iOS, we arent able to get the code values and have to treat it as numbers.