### PR TITLE
Update AndroidManifest.xml - remove package value from manifest

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,7 @@ def safeExtGet(prop, fallback) {
 }
 
 android {
+    namespace "com.rnbiometrics"
     compileSdkVersion safeExtGet('compileSdkVersion', 29)
 
     defaultConfig {

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.rnbiometrics">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.USE_BIOMETRIC" />
     <uses-permission android:name="android.permission.USE_FINGERPRINT" />
 </manifest>


### PR DESCRIPTION
getting issue when trying to build my project

this is the error that I am getting 


FAILURE: Build failed with an exception.
--
  |  
  | * What went wrong:
  | Execution failed for task ':react-native-biometrics:processDebugManifest'.
  | > A failure occurred while executing com.android.build.gradle.tasks.ProcessLibraryManifest$ProcessLibWorkAction
  | > Incorrect package="com.rnbiometrics" found in source AndroidManifest.xml: /Users/builder/uibuilder/work/working-dir/node_modules/react-native-biometrics/android/src/main/AndroidManifest.xml.
  | Setting the namespace via the package attribute in the source AndroidManifest.xml is no longer supported.
  | Recommendation: remove package="com.rnbiometrics" from the source AndroidManifest.xml: /Users/builder/uibuilder/work/working-dir/node_modules/react-native-biometrics/android/src/main/AndroidManifest.xml.

from android [documentation](https://developer.android.com/guide/topics/manifest/manifest-element)

In the Gradle-based build system, starting with AGP 7.3, don't set the package value in the source manifest file directly. For more information, see [Set the application ID](https://developer.android.com/studio/build/configure-app-module#set-application-id).


