### PR TITLE
biometricKeysExistAndSignatureValid / return error code with error message

### DIFF
--- a/android/src/main/java/com/rnbiometrics/CreateSignatureCallback.java
+++ b/android/src/main/java/com/rnbiometrics/CreateSignatureCallback.java
@@ -30,7 +30,7 @@ public class CreateSignatureCallback extends BiometricPrompt.AuthenticationCallb
             resultMap.putString("error", "User cancellation");
             this.promise.resolve(resultMap);
         } else {
-            this.promise.reject(errString.toString(), errString.toString());
+            this.promise.reject(String.valueOf(errorCode), errString.toString());
         }
     }
 

--- a/android/src/main/java/com/rnbiometrics/ReactNativeBiometrics.java
+++ b/android/src/main/java/com/rnbiometrics/ReactNativeBiometrics.java
@@ -270,4 +270,32 @@ public class ReactNativeBiometrics extends ReactContextBaseJavaModule {
             return false;
         }
     }
+    
+    @ReactMethod
+    public void biometricKeysExistAndSignatureValid(Promise promise) {
+        try {
+            boolean doesBiometricKeyExist = doesBiometricKeyExistAndSignatureValid();
+            WritableMap resultMap = new WritableNativeMap();
+            resultMap.putBoolean("keysExist", doesBiometricKeyExist);
+            promise.resolve(resultMap);
+        } catch (Exception e) {
+            promise.reject("Error checking if biometric key exists: " + e.getMessage(),
+                    "Error checking if biometric key exists: " + e.getMessage());
+        }
+    }
+
+    protected boolean doesBiometricKeyExistAndSignatureValid() {
+        try {
+            Signature signature = Signature.getInstance("SHA256withRSA");
+            KeyStore keyStore = KeyStore.getInstance("AndroidKeyStore");
+            keyStore.load(null);
+
+            PrivateKey privateKey = (PrivateKey) keyStore.getKey(biometricKeyAlias, null);
+            signature.initSign(privateKey);
+
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
 }

--- a/index.ts
+++ b/index.ts
@@ -51,6 +51,9 @@ interface SimplePromptResult {
   success: boolean
   error?: string
 }
+interface BiometricKeysExistAndSignatureValidResult {
+  keysExist: boolean
+}
 
 /**
  * Enum for touch id sensor type
@@ -131,6 +134,15 @@ export module ReactNativeBiometricsLegacy {
    */
   export function simplePrompt(simplePromptOptions: SimplePromptOptions): Promise<SimplePromptResult> {
     return new ReactNativeBiometrics().simplePrompt(simplePromptOptions)
+  }
+
+  /**
+   * Returns promise that resolves to an object with object.keysExists = true | false
+   * indicating if the keys were found to exist or not and signature valid
+   * @returns {Promise<Object>} Promise that resolves to object with details aobut the existence of keys
+   */
+   export function biometricKeysExistAndSignatureValid(): Promise<BiometricKeysExistAndSignatureValidResult> {
+    return new ReactNativeBiometrics().biometricKeysExistAndSignatureValid();
   }
 }
 
@@ -220,5 +232,14 @@ export default class ReactNativeBiometrics {
         allowDeviceCredentials: this.allowDeviceCredentials,
         ...simplePromptOptions
       })
+    }
+    
+     /**
+     * Returns promise that resolves to an object with object.keysExists = true | false
+     * indicating if the keys were found to exist or not and signature valid
+     * @returns {Promise<Object>} Promise that resolves to object with details aobut the existence of keys
+     */
+    biometricKeysExistAndSignatureValid(): Promise<BiometricKeysExistAndSignatureValidResult> {
+      return bridge.biometricKeysExistAndSignatureValid();
     }
   }

--- a/ios/ReactNativeBiometrics.m
+++ b/ios/ReactNativeBiometrics.m
@@ -221,6 +221,24 @@ RCT_EXPORT_METHOD(biometricKeysExist: (RCTPromiseResolveBlock)resolve rejecter:(
       resolve(result);
     }
   });
+  
+  RCT_EXPORT_METHOD(biometricKeysExistAndSignatureValid: (RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+  dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
+    BOOL biometricKeyExists = [self doesBiometricKeyExist];
+
+    if (biometricKeyExists) {
+      NSDictionary *result = @{
+        @"keysExist": @(YES)
+      };
+      resolve(result);
+    } else {
+      NSDictionary *result = @{
+        @"keysExist": @(NO)
+      };
+      resolve(result);
+    }
+  });
+}
 }
 
 - (NSData *) getBiometricKeyTag {

--- a/ios/ReactNativeBiometrics.m
+++ b/ios/ReactNativeBiometrics.m
@@ -221,8 +221,9 @@ RCT_EXPORT_METHOD(biometricKeysExist: (RCTPromiseResolveBlock)resolve rejecter:(
       resolve(result);
     }
   });
-  
-  RCT_EXPORT_METHOD(biometricKeysExistAndSignatureValid: (RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
+}
+
+RCT_EXPORT_METHOD(biometricKeysExistAndSignatureValid: (RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {
   dispatch_async(dispatch_get_global_queue( DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
     BOOL biometricKeyExists = [self doesBiometricKeyExist];
 
@@ -238,7 +239,6 @@ RCT_EXPORT_METHOD(biometricKeysExist: (RCTPromiseResolveBlock)resolve rejecter:(
       resolve(result);
     }
   });
-}
 }
 
 - (NSData *) getBiometricKeyTag {


### PR DESCRIPTION
Added the biometricKeysExistAndSignatureValid method to not only check for the presence of biometric keys but also validate whether the key matches the one originally used during biometric setup. Used for Android.

Added support for returning an error code.